### PR TITLE
Simpler way to validate enums

### DIFF
--- a/src/tasks/dto/get-tasks-filter.dto.ts
+++ b/src/tasks/dto/get-tasks-filter.dto.ts
@@ -3,9 +3,9 @@ import { IsOptional, IsIn, IsNotEmpty } from 'class-validator';
 
 export class GetTasksFilterDto {
   @IsOptional()
-  @IsIn([TaskStatus.OPEN, TaskStatus.IN_PROGRESS, TaskStatus.DONE])
+  @IsIn(Object.values(TaskStatus))
   status: TaskStatus;
-
+  
   @IsOptional()
   @IsNotEmpty()
   search: string;

--- a/src/tasks/pipes/task-status-validation.pipe.ts
+++ b/src/tasks/pipes/task-status-validation.pipe.ts
@@ -1,25 +1,13 @@
+import { TaskStatus } from './../task.model';
 import { PipeTransform, BadRequestException } from '@nestjs/common';
-import { TaskStatus } from '../task-status.enum';
 
 export class TaskStatusValidationPipe implements PipeTransform {
-  readonly allowedStatuses = [
-    TaskStatus.OPEN,
-    TaskStatus.IN_PROGRESS,
-    TaskStatus.DONE,
-  ];
-
   transform(value: any) {
-    value = value.toUpperCase();
 
-    if (!this.isStatusValid(value)) {
+    if (!Object.values(TaskStatus).includes(value)) {
       throw new BadRequestException(`"${value}" is an invalid status`);
     }
 
     return value;
-  }
-
-  private isStatusValid(status: any) {
-    const idx = this.allowedStatuses.indexOf(status);
-    return idx !== -1;
   }
 }


### PR DESCRIPTION
Rather than creating extra code for checking if status string is a valid TaskStatus enum, you can use Object.values(TaskStatus). It will also make it easier to maintain the code in the future if you add new enums.
